### PR TITLE
Add avatarurl to config-example

### DIFF
--- a/config/config-example.js
+++ b/config/config-example.js
@@ -178,6 +178,9 @@ exports.customavatars = {
 	//'userid': 'customavatar.png'
 };
 
+//Custom avatars appear in profile by specifiying server url.
+exports.avatarurl = '';
+
 // Tournament announcements
 // When tournaments are created in rooms listed below, they will be announced in
 // the server's main tournament room (either the specified tourroom or by default


### PR DESCRIPTION
We are using Config.avatarurl in profile yet it is not present in config-example. This adds it in.