### PR TITLE
Forcefully prefix http:// to links without it

### DIFF
--- a/chat-plugins/customavatar.js
+++ b/chat-plugins/customavatar.js
@@ -39,6 +39,7 @@ exports.commands = {
 
 			var name = toId(parts[0]);
 			var image_url = parts[1];
+			if (image_url.indexOf('http://') !== 0 && image_url.indexOf('https://') !== 0) image_url = 'http://' + image_url;
 			var ext = path.extname(image_url);
 
 			if (!name || !image_url) return this.parse('/help customavatar');

--- a/chat-plugins/customavatar.js
+++ b/chat-plugins/customavatar.js
@@ -39,7 +39,7 @@ exports.commands = {
 
 			var name = toId(parts[0]);
 			var image_url = parts[1];
-			if (image_url.indexOf('http://') !== 0 && image_url.indexOf('https://') !== 0) image_url = 'http://' + image_url;
+			if (image_url.match(/^https:\/\/|^http:\/\//i)) image_url = 'http://' + image_url;
 			var ext = path.extname(image_url);
 
 			if (!name || !image_url) return this.parse('/help customavatar');

--- a/chat-plugins/customavatar.js
+++ b/chat-plugins/customavatar.js
@@ -39,7 +39,7 @@ exports.commands = {
 
 			var name = toId(parts[0]);
 			var image_url = parts[1];
-			if (image_url.match(/^https:\/\/|^http:\/\//i)) image_url = 'http://' + image_url;
+			if (image_url.match(/^https?:\/\//i)) image_url = 'http://' + image_url;
 			var ext = path.extname(image_url);
 
 			if (!name || !image_url) return this.parse('/help customavatar');


### PR DESCRIPTION
Using the request module for URLs without http:// or https:// prefixed to it will return an "invalid URI" error.