### PR TITLE
Fix LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,6 @@
 Copyright (c) 2015 Philip La
+Copyright (c) 2011-2015 Guangcong Luo and other contributors
+http://pokemonshowdown.com/
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the


### PR DESCRIPTION
The MIT license allows you to do anything you want EXCEPT remove the copyright notice or permission notice.

You can't remove my copyright notice. You can add yours on top of it, if you'd like, but you can't remove mine.