### PR TITLE
README: Promotion commands should be global.

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -13,7 +13,7 @@ Replace `USER` with the username that you would like to become an Administrator.
 
 This username must be registered. If you do not have a registered account, you can create one using the Register button in the settings menu (it looks like a gear) in the upper-right of Pokémon Showdown.
 
-Once you're an administrator, you can promote/demote others easily with the `/admin`, `/leader`, `/mod`, etc commands.
+Once you're an administrator, you can promote/demote others easily with the `/globaladmin`, `/globalleader`, `/globalmod`, etc commands.
 
 Setting The Server
 ------------------------------------------------------------------------


### PR DESCRIPTION
Since global promotion commands begin with global (and have for a while now), it's better to let people know at the beginning to use /global[rank] rather than them getting the error reply to use /global[rank].