### PR TITLE
Fix for 2 vulnerable dependency paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dem-feels": "^1.6.0",
     "moment": "2.11.2",
     "origindb": "2.5.2",
-    "request": "2.67.0",
+    "request": "2.74.0",
     "sockjs": "0.3.18"
   },
   "optionalDependencies": {


### PR DESCRIPTION
Showdown-Boilerplate currently has a 2 vulnerable dependency paths, introducing 2 different types of known vulnerabilities.

This PR fixes vulnerable dependencies, [ReDOS vulnerability](https://snyk.io/vuln/npm:tough-cookie:20160722) in the `tough-cookie` dependency and [remote memory exposure ](https://snyk.io/vuln/npm:request:20160119) vulnerability in the `request` dependency.

You can see [Snyk test report](https://snyk.io/test/github/CreaturePhil/Showdown-Boilerplate) of this project for details. 

This PR changes `Package.json` to upgrade `request` to the newer 2.74.0 version, and will fix all the vulnerabilities.

You can get alerts and fix PRs for future vulnerabilities for free by [watching this repo with Snyk](https://snyk.io/add).


Stay Secure,
The Snyk Team