### PR TITLE
Badge to show you’re free of known vulnerabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Build Status](https://travis-ci.org/CreaturePhil/Showdown-Boilerplate.svg)](https://travis-ci.org/CreaturePhil/Showdown-Boilerplate)
 [![Dependency Status](https://david-dm.org/CreaturePhil/Showdown-Boilerplate.svg)](https://david-dm.org/CreaturePhil/Showdown-Boilerplate)
 [![devDependency Status](https://david-dm.org/CreaturePhil/Showdown-Boilerplate/dev-status.svg)](https://david-dm.org/CreaturePhil/Showdown-Boilerplate#info=devDependencies)
+[![Known Vulnerabilities](https://snyk.io/test/github/CreaturePhil/Showdown-Boilerplate/49ca7d99ca9c88f8b3ab5296df4c82c97bd411a2/badge.svg)](https://snyk.io/test/github/CreaturePhil/Showdown-Boilerplate/49ca7d99ca9c88f8b3ab5296df4c82c97bd411a2)
 
 Showdown Boilerplate is a template for [Pokémon Showdown](https://github.com/Zarel/Pokemon-Showdown)
 private servers.


### PR DESCRIPTION
Showdown-Boilerplate has no vulnerabilities, which is awesome! 

This PR adds a badge that shows you’re free of known vulnerabilities. Note that the badge works off the latest master branch.

Adding the badge will show others that you care about security, and that they should care, too. 
(It will also help to spread the word about Snyk, which would benefit us a lot!). 

Check our [documentation](https://snyk.io/docs/badges/#github-badge) if you’d like to know more about our badges. 

Stay secure, 
The Snyk team
